### PR TITLE
Correctly Display All Codepoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
 
 	<script type="text/javascript" charset="utf-8">
 		$(document).ready(function() {
+      var fromCodePoint = String.fromCodePoint || String.fromCharCode;
+
 			$("textarea").focus();
 
 			$("textarea").on("input", function() {
@@ -46,7 +48,7 @@
 
 					// Add it
 					var html = "<span>";
-					var character = String.fromCharCode(hexList[i]);
+					var character = fromCodePoint(hexList[i]);
 
 					newLine = false;
 


### PR DESCRIPTION
I have replaced [`String.fromCharCode()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/ReferenceI/Global_Objects/String/fromCharCode) with [`String.fromCodePoint()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint) (if available) because `String.fromCharCode()` is unable to handle codepoints that are encoded with more than 16-bit.

![screen shot 2017-06-19 at 20 30 37](https://user-images.githubusercontent.com/4602612/27299911-2f34597c-552e-11e7-8a4b-2c1dbfbbec17.png)
